### PR TITLE
Add PHP 7.2 and 7.3 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ php:
     - '5.6'
     - '7.0'
     - '7.1'
+    - '7.2'
+    - '7.3'
 
 before_script:
     - if [[ $TRAVIS_PHP_VERSION = '5.4' ]]; then PHPUNIT_FLAGS="--coverage-clover ./clover.xml"; else PHPUNIT_FLAGS=""; fi


### PR DESCRIPTION
Adds both PHP 7.2 and 7.3 to Travis for testing.
This is important as the versions <7.2 will be EOL end of this year.