### PR TITLE
44 - add '||' and '&&' as binary boolean operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ indexlist   = index (',' index)*
 arrayslice  = index? ':' index? ':' index?
 filterexpr  = '?(' ors ')'
 
-ors         = ands (' or ' ands)*
-ands        = expr (' and ' expr)*
+ors         = ands (' ' (or|\|\|) ' ' ands)*
+ands        = expr (' ' (and|&&) ' ' expr)*
 expr        = 'not'? (value | comp)
 comp        = value ('==' | '!=' | '<' | '>' | '<=' | '>=' | '=~') value
 value       = (jsonpath | childpath | number | string | boolean | regpattern | null | length)

--- a/src/Galbar/JsonPath/JsonObject.php
+++ b/src/Galbar/JsonPath/JsonObject.php
@@ -126,8 +126,8 @@ class JsonObject
     const RE_STRING = '/^(?:\'(.*)\'|"(.*)")$/';
     const RE_REGEX_EXPR = '/^\/.*\/$/';
     const RE_NEXT_SUBEXPR = '/.*?(\(|\)|\[|\])/';
-    const RE_OR = '/\s+or\s+/';
-    const RE_AND = '/\s+and\s+/';
+    const RE_OR = '/\s+(or|\|\|)\s+/';
+    const RE_AND = '/\s+(and|&&)\s+/';
     const RE_NOT = '/^not\s+(.*)/';
 
     // Tokens

--- a/tests/Galbar/JsonPath/JsonObjectTest.php
+++ b/tests/Galbar/JsonPath/JsonObjectTest.php
@@ -325,6 +325,13 @@ class JsonPathTest extends \PHPUnit_Framework_TestCase
             ),
             array(
                 array(
+                    19.95,
+                    8.99
+                ),
+                "$..*[?(@.category == 'fiction' && @.price < 10 || @.color == \"red\")].price"
+            ),
+            array(
+                array(
                     8.95
                 ),
                 "$.store.book[?(not @.category == 'fiction')].price"
@@ -346,6 +353,12 @@ class JsonPathTest extends \PHPUnit_Framework_TestCase
                     true
                 ),
                 "$.store[?(not @..price or @..color == 'red')].available"
+            ),
+            array(
+                array(
+                    true
+                ),
+                "$.store[?(not @..price || @..color == 'red')].available"
             ),
             array(
                 false,
@@ -599,6 +612,13 @@ class JsonPathTest extends \PHPUnit_Framework_TestCase
             ),
             array(
                 array(
+                    19.95,
+                    8.99
+                ),
+                "$..*[?(@.category == 'fiction' && @.price < 10 || @.color == \"red\")].price"
+            ),
+            array(
+                array(
                     8.95
                 ),
                 "$.store.book[?(not @.category == 'fiction')].price"
@@ -620,6 +640,12 @@ class JsonPathTest extends \PHPUnit_Framework_TestCase
                     true
                 ),
                 "$.store[?(not @..price or @..color == 'red')].available"
+            ),
+            array(
+                array(
+                    true
+                ),
+                "$.store[?(not @..price || @..color == 'red')].available"
             ),
             array(
                 false,


### PR DESCRIPTION
They exist together with 'and' and 'or'.

Fix #44 