### PR TITLE
Normalize behavior of .length operation.

### DIFF
--- a/src/Galbar/JsonPath/JsonObject.php
+++ b/src/Galbar/JsonPath/JsonObject.php
@@ -219,7 +219,7 @@ class JsonObject
     public function get($jsonPath)
     {
         list($result, $hasDiverged) = JsonPath::get($this->jsonObject, $jsonPath);
-        if ($this->smartGet && $result !== false && !$hasDiverged && is_array($result)) {
+        if ($this->smartGet && $result !== false && !$hasDiverged) {
             return $result[0];
         }
         return $result;
@@ -251,7 +251,7 @@ class JsonObject
                 $jsonObject->jsonObject = &$value;
                 $objs[] = $jsonObject;
             }
-            if ($this->smartGet && !$hasDiverged && is_array($result)) {
+            if ($this->smartGet && !$hasDiverged) {
                 return $objs[0];
             }
             return $objs;

--- a/src/Galbar/JsonPath/JsonPath.php
+++ b/src/Galbar/JsonPath/JsonPath.php
@@ -47,12 +47,8 @@ class JsonPath
                     $newSelection = array_merge($newSelection, $result);
                 }
                 if (empty($newSelection) && Language\Token::LENGTH === $childName) {
-                    if (count($selection) > 1) {
-                        foreach ($selection as $item) {
-                            $newSelection[] = is_array($item) ? count($item) : strlen($item);
-                        }
-                    } else if (count($selection) == 1) {
-                        $newSelection = is_array($selection[0]) ? count($selection[0]) : strlen($selection[0]);
+                    foreach ($selection as $item) {
+                        $newSelection[] = is_array($item) ? count($item) : strlen($item);
                     }
                 }
                 if (empty($newSelection)) {

--- a/tests/Galbar/JsonPath/JsonObjectLengthOperatorTest.php
+++ b/tests/Galbar/JsonPath/JsonObjectLengthOperatorTest.php
@@ -156,7 +156,7 @@ class JsonObjectLengthOperatorTest extends \PHPUnit_Framework_TestCase
         $jsonObject = new JsonObject($this->json);
         $result = $jsonObject->get($jsonPath);
         $this->assertEquals(
-            3,
+            [3],
             $result
         );
 
@@ -164,14 +164,14 @@ class JsonObjectLengthOperatorTest extends \PHPUnit_Framework_TestCase
         $jsonPath = '$.music.bands[0].albums[0].length.length';
         $result = $jsonObject->get($jsonPath);
         $this->assertEquals(
-            5,
+            [5],
             $result
         );
 
         $jsonPath = '$.music.bands[0].albums[1].title.length';
         $result = $jsonObject->get($jsonPath);
         $this->assertEquals(
-            6,
+            [6],
             $result
         );
     }
@@ -214,6 +214,61 @@ class JsonObjectLengthOperatorTest extends \PHPUnit_Framework_TestCase
         /** Arrays Count Length Test */
         $jsonPath = '$.music.bands[*].albums.length';
         $jsonObject = new JsonObject($this->json);
+        $result = $jsonObject->get($jsonPath);
+        $this->assertEquals(
+            [
+                3,
+                3
+            ],
+            $result
+        );
+
+        /** String Length Test */
+        $jsonPath = '$.music.bands[0].albums[*].length.length';
+        $result = $jsonObject->get($jsonPath);
+        $this->assertEquals(
+            [
+                5,
+                5,
+                6
+            ],
+            $result
+        );
+
+        $jsonPath = '$.music.bands[0].albums[*].title.length';
+        $result = $jsonObject->get($jsonPath);
+        $this->assertEquals(
+            [
+                5,
+                6,
+                5
+            ],
+            $result
+        );
+
+        $jsonPath = '$.music.bands[*].albums[*].length.length';
+        $result = $jsonObject->get($jsonPath);
+        $this->assertEquals(
+            [
+                5,
+                5,
+                6,
+                6,
+                6,
+                6
+            ],
+            $result
+        );
+    }
+
+    /**
+     * @throws InvalidJsonException
+     */
+    public function testArrayLengthSmartGet()
+    {
+        /** Arrays Count Length Test */
+        $jsonPath = '$.music.bands[*].albums.length';
+        $jsonObject = new JsonObject($this->json, true);
         $result = $jsonObject->get($jsonPath);
         $this->assertEquals(
             [


### PR DESCRIPTION
.length now behaves as any other operator: return array of results unless smartGet enabled, then it will return the value directly if the path does not diverge