### PR TITLE
Support selecting element from result set of children filter

### DIFF
--- a/src/Galbar/JsonPath/JsonPath.php
+++ b/src/Galbar/JsonPath/JsonPath.php
@@ -60,7 +60,7 @@ class JsonPath
             } else if (Language\ChildSelector::match($jsonPath, $match)) {
                 $contents = $match[0];
                 foreach ($selection as &$partial) {
-                    list($result, $newHasDiverged) = Operation\SelectChildren::apply($root, $partial, $contents, $createInexistent);
+                    list($result, $newHasDiverged) = Operation\SelectChildren::apply($root, $partial, $contents, $createInexistent, isset($match[1]) ? $match[1] : "");
                     $newSelection = array_merge($newSelection, $result);
                 }
                 if (empty($newSelection)) {

--- a/src/Galbar/JsonPath/Operation/SelectChildren.php
+++ b/src/Galbar/JsonPath/Operation/SelectChildren.php
@@ -22,7 +22,7 @@ use JsonPath\Expression;
 
 class SelectChildren
 {
-    public static function apply(&$root, &$partial, $contents, $createInexistent = false)
+    public static function apply(&$root, &$partial, $contents, $createInexistent = false, $next="")
     {
         if (!is_array($partial)) {
             return array(array(), false);
@@ -69,6 +69,13 @@ class SelectChildren
             foreach ($partial as &$child) {
                 if (Expression\BooleanExpression::evaluate($root, $child, $subexpr)) {
                     $result[] = &$child;
+                }
+            }
+            if (Language\ChildSelector::match($next, $nextMatch)) {
+                if (isset($nextMatch[0]) && is_numeric($nextMatch[0])) {
+                    // Next we will be trying to get nth child, so put results in parent array
+                    $result = array($result);
+                    $hasDiverged = false;
                 }
             }
         } else {

--- a/src/Galbar/JsonPath/Operation/SelectChildren.php
+++ b/src/Galbar/JsonPath/Operation/SelectChildren.php
@@ -71,7 +71,7 @@ class SelectChildren
                     $result[] = &$child;
                 }
             }
-            if (Language\ChildSelector::match($next, $nextMatch)) {
+            if ($next && Language\ChildSelector::match($next, $nextMatch)) {
                 if (isset($nextMatch[0]) && is_numeric($nextMatch[0])) {
                     // Next we will be trying to get nth child, so put results in parent array
                     $result = array($result);

--- a/tests/Galbar/JsonPath/JsonObjectTest.php
+++ b/tests/Galbar/JsonPath/JsonObjectTest.php
@@ -661,6 +661,10 @@ class JsonPathTest extends \PHPUnit_Framework_TestCase
                 "$.store.book[?(@.category != 'fiction')].price"
             ),
             array(
+                12.99,
+                "$.store.book[?(@.category == 'fiction')][0].price"
+            ),
+            array(
                 array(
                     "red"
                 ),


### PR DESCRIPTION
Added support to get elements from a result array after filtering children from a selected list. Implemented by looking forward if the next step is to take an specific element out of the results.

e.g.:
`{"people": [{"age": 20}, {"age": 30}, {"age": 40}]}`

`$.people[?(@.age > 20)][1].age` is now possible.
