### PR TITLE
Add In|Not In Array Operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ expr        = ( 'not ' | '! ' )? (value | comp)
 comp        = value ('==' | '!=' | '<' | '>' | '<=' | '>=' | '=~') value
 value       = (jsonpath | childpath | number | string | boolean | regpattern | null | length)
 length      = (jsonpath | childpath) '.length'
+in array    = var_name in [ value, value ]
 ```
 
 ### Limitations on the specification:  
@@ -212,6 +213,7 @@ JsonPath | Result
 `$[store]` | The store.
 `$['store']` | The store.
 `$..book[*][title, 'category', "author"]` | title, category and author of all books.
+`$..book[?(@.author in [$.authors[0], $.authors[2]])]` | All books by "Nigel Rees" or "Herman Melville".
 See more examples in the `./tests/Galbar/JsonPath` folder.
 
 Test

--- a/src/Galbar/JsonPath/Expression/BooleanExpression.php
+++ b/src/Galbar/JsonPath/Expression/BooleanExpression.php
@@ -46,8 +46,9 @@ class BooleanExpression
             $result = false;
             if (preg_match(Language\Regex::BINOP_COMP, $subexpr, $match)) {
                 $result = Comparison::evaluate($root, $partial, $match[1], $match[2], $match[3]);
-            }
-            else {
+            } elseif (preg_match(Language\Regex::BINOP_IN_ARRAY, $subexpr, $match)) {
+                $result = InArray::evaluate($root, $partial, $match[1], $match[2]);
+            } else {
                 $result = Value::evaluate($root, $partial, $subexpr);
             }
             if ($not) {

--- a/src/Galbar/JsonPath/Expression/InArray.php
+++ b/src/Galbar/JsonPath/Expression/InArray.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace JsonPath\Expression;
+
+class InArray
+{
+    private const SEPARATOR = ',';
+
+    public static function evaluate(&$root, &$partial, $attribute, $listExpression)
+    {
+        $value = Value::evaluate($root, $partial, trim($attribute));
+        $list = self::prepareList($root, $partial, $listExpression);
+
+        return in_array($value, $list, true);
+    }
+
+    private static function prepareList(&$root, &$partial, string $expression)
+    {
+        if (strpos($expression, self::SEPARATOR) === false) {
+            return [Value::evaluate($root, $partial, trim($expression))];
+        }
+
+        return array_map(
+            fn ($value) => Value::evaluate($root, $partial, trim($value)),
+            explode(self::SEPARATOR, $expression)
+        );
+    }
+}
+

--- a/src/Galbar/JsonPath/Language/Regex.php
+++ b/src/Galbar/JsonPath/Language/Regex.php
@@ -38,6 +38,7 @@ class Regex
     const EXPR_STRING = '/^(?:\'(.*)\'|"(.*)")$/';
     const EXPR_REGEX = '/^\/.*\/i?x?$/';
     const BINOP_COMP = '/^(.+)\s*(==|!=|<=|>=|<|>|=\~)\s*(.+)$/';
+    const BINOP_IN_ARRAY = '/^(.+)\s*in\s*\[(.+)\]$/';
     const BINOP_OR = '/\s+(or|\|\|)\s+/';
     const BINOP_AND = '/\s+(and|&&)\s+/';
     const OP_NOT = '/^(not|!)\s+(.*)/';

--- a/tests/Galbar/JsonPath/JsonObjectTest.php
+++ b/tests/Galbar/JsonPath/JsonObjectTest.php
@@ -17,9 +17,9 @@
 
 namespace Tests;
 
-use JsonPath\JsonObject;
 use JsonPath\InvalidJsonException;
 use JsonPath\InvalidJsonPathException;
+use JsonPath\JsonObject;
 
 /**
  * Class JsonObjectTest
@@ -449,7 +449,6 @@ class JsonPathTest extends \PHPUnit_Framework_TestCase
      * testSmartGet
      *
      * @param array $expected expected
-     * @param array $jsonObject jsonObject
      * @param string $jsonPath jsonPath
      *
      * @return void
@@ -742,6 +741,157 @@ class JsonPathTest extends \PHPUnit_Framework_TestCase
             array(
                 array(1, 2, 3),
                 '$["Bike models"]'
+            ),
+            array(
+                array(
+                    array(
+                        "category" => "fiction",
+                        "author" => "Evelyn Waugh",
+                        "title" => "Sword of Honour",
+                        "price" => 12.99,
+                        "available" => false
+                    ),
+                    array(
+                        "category" => "fiction",
+                        "author" => "J. R. R. Tolkien",
+                        "isbn" => "0-395-19395-8",
+                        "title" => "The Lord of the Rings",
+                        "price" => 22.99,
+                        "available" => false
+                    )
+                ),
+                "$.store.book[?(@.title in ['Sword of Honour', 'The Lord of the Rings'])]",
+            ),
+            array(
+                array(
+                    array(
+                        "category" => "reference",
+                        "author" => "Nigel Rees",
+                        "title" => "Sayings of the Century",
+                        "price" => 8.95,
+                        "available" => true,
+                    ),
+                    array(
+                        "category" => "fiction",
+                        "author" => "Evelyn Waugh",
+                        "title" => "Sword of Honour",
+                        "price" => 12.99,
+                        "available" => false,
+                    ),
+                    array(
+                        "category" => "fiction",
+                        "author" => "J. R. R. Tolkien",
+                        "title" => "The Lord of the Rings",
+                        "isbn" => "0-395-19395-8",
+                        "price" => 22.99,
+                        "available" => false,
+                    ),
+                ),
+                "$.store.book[?(@.author == 'Nigel Rees' or @.title in ['Sword of Honour', 'The Lord of the Rings'])]",
+            ),
+            array(
+                array(
+                    array(
+                        "category" => "fiction",
+                        "author" => "Herman Melville",
+                        "title" => "Moby Dick",
+                        "isbn" => "0-553-21311-3",
+                        "price" => 8.99,
+                        "available" => true,
+                    )
+                ),
+                "$.store.book[?(@.isbn in ['0-553-21311-3', '0-395-19395-8'] and @.available == true)]"
+            ),
+            array(
+                array(
+                    array(
+                        "category" => "reference",
+                        "author" => "Nigel Rees",
+                        "title" => "Sayings of the Century",
+                        "price" => 8.95,
+                        "available" => true,
+                    ),
+                    array(
+                        "category" => "fiction",
+                        "author" => "Herman Melville",
+                        "title" => "Moby Dick",
+                        "isbn" => "0-553-21311-3",
+                        "price" => 8.99,
+                        "available" => true,
+                    )
+                ),
+                "$.store.book[?(not @.title in ['Sword of Honour', 'The Lord of the Rings'])]"
+            ),
+            array(
+                array(
+                    array(
+                        "category" => "fiction",
+                        "author" => "Evelyn Waugh",
+                        "title" => "Sword of Honour",
+                        "price" => 12.99,
+                        "available" => false,
+                    )
+                ),
+                "$.store.book[?(not @.isbn in ['0-553-21311-3', '0-395-19395-8'] and @.available == false)]"
+            ),
+            array(
+                array(
+                    array(
+                        "category" => "reference",
+                        "author" => "Nigel Rees",
+                        "title" => "Sayings of the Century",
+                        "price" => 8.95,
+                        "available" => true,
+                    ),
+                    array(
+                        "category" => "fiction",
+                        "author" => "Evelyn Waugh",
+                        "title" => "Sword of Honour",
+                        "price" => 12.99,
+                        "available" => false,
+                    )
+                ),
+                "$.store.book[?(@.price in [12.99, 8.95])]"
+            ),
+            array(
+                array(
+                    array(
+                        "category" => "reference",
+                        "author" => "Nigel Rees",
+                        "title" => "Sayings of the Century",
+                        "price" => 8.95,
+                        "available" => true,
+                    ),
+                    array(
+                        "category" => "fiction",
+                        "author" => "Herman Melville",
+                        "title" => "Moby Dick",
+                        "isbn" => "0-553-21311-3",
+                        "price" => 8.99,
+                        "available" => true,
+                    )
+                ),
+                "$.store.book[?(@.available in [ true ])]"
+            ),
+            array(
+                array(
+                    array(
+                        "category" => "reference",
+                        "author" => "Nigel Rees",
+                        "title" => "Sayings of the Century",
+                        "price" => 8.95,
+                        "available" => true,
+                    ),
+                    array(
+                        "category" => "fiction",
+                        "author" => "Herman Melville",
+                        "title" => "Moby Dick",
+                        "isbn" => "0-553-21311-3",
+                        "price" => 8.99,
+                        "available" => true,
+                    )
+                ),
+                "$..book[?(@.author in [$.authors[0], $.authors[2]])]"
             )
         );
     }
@@ -1016,7 +1166,13 @@ EOF;
         return array(
             array('$[store', '[store'),
             array('$[{fail}]', '{fail}'),
-            array('a.bc', 'a.bc')
+            array('a.bc', 'a.bc'),
+            array("$.store.book[?(@.title in ['foo']])]", "[?(@.title in ['foo']])]"),
+            array("$.store.book[?(@.title in [['foo'])]", "[?(@.title in [['foo'])]"),
+            array("$.store.book[?(@.title in ['foo')]", "[?(@.title in ['foo')]"),
+            array("$.store.book[?(@.title in 'foo'])]", "[?(@.title in 'foo'])]"),
+            array("$.store.book[?(@.title in 'foo')]", " in 'foo'"),
+            array("$.store.book[?(@.title ['foo'])]", " ['foo']"),
         );
     }
 


### PR DESCRIPTION
First of all, congratulations on the amazing library, it has helped me a lot! :clap: 

I opened this PR to allow the use of `in [foo, bar]` instead of multiple clauses connected with `or` or one clause with `regex`. 

NOTE: In my research I couldn't find a syntax pattern for this clause so I adopted the JS array pattern (`[]`). 