### PR TITLE
feat: Allow in_array expression to fetch all available items - related to #68

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ expr        = ( 'not ' | '! ' )? (value | comp | in_array)
 comp        = value ('==' | '!=' | '<' | '>' | '<=' | '>=' | '=~') value
 value       = (jsonpath | childpath | number | string | boolean | regpattern | null | length)
 length      = (jsonpath | childpath) '.length'
-in_array    = value 'in' '[' value (',' value)* ']'
+in_array    = value 'in' '[' value (',' value)* | jsonpath ']'
 ```
 
 ¹`var_name`: the regex roughly translates to "any valid JavaScript variable
@@ -220,6 +220,7 @@ JsonPath | Result
 `$['store']` | The store.
 `$..book[*][title, 'category', "author"]` | title, category and author of all books.
 `$..book[?(@.author in [$.authors[0], $.authors[2]])]` | All books by "Nigel Rees" or "Herman Melville".
+`$..book[?(@.author in [$.authors])]` | All books written by an author in the authors list.
 `$.store.book[?(@.category == 'fiction' and @.price < 10 or @.color == "red")].price` | Books of fiction with a price lower than 10 or something with of color red. (`and` takes precedence to `or`)
 
 See more examples in the `./tests/Galbar/JsonPath` folder.

--- a/src/Galbar/JsonPath/Expression/InArray.php
+++ b/src/Galbar/JsonPath/Expression/InArray.php
@@ -2,6 +2,8 @@
 
 namespace JsonPath\Expression;
 
+use JsonPath\Language;
+
 class InArray
 {
     const SEPARATOR = ',';
@@ -17,6 +19,22 @@ class InArray
     private static function prepareList(&$root, &$partial, $expression)
     {
         if (strpos($expression, self::SEPARATOR) === false) {
+            if ($expression[0] === Language\Token::ROOT){
+                list($result, $_) = \JsonPath\JsonPath::subtreeGet($root, $root, $expression);
+                if (!$_) {
+                    $result = reset($result);
+                }
+                return $result;
+            }
+            else if ($expression[0] === Language\Token::CHILD) {
+                $expression[0] = Language\Token::ROOT;
+                list($result, $_) = \JsonPath\JsonPath::subtreeGet($root, $partial, $expression);
+                if (!$_) {
+                    $result = reset($result);
+                }
+                return $result;
+            }
+
             return [Value::evaluate($root, $partial, trim($expression))];
         }
 

--- a/tests/Galbar/JsonPath/JsonObjectTest.php
+++ b/tests/Galbar/JsonPath/JsonObjectTest.php
@@ -896,6 +896,41 @@ class JsonObjectTest extends \PHPUnit_Framework_TestCase
                     )
                 ),
                 "$..book[?(@.author in [$.authors[0], $.authors[2]])]"
+            ),
+            array(
+                array(
+                    array(
+                        "category" => "reference",
+                        "author" => "Nigel Rees",
+                        "title" => "Sayings of the Century",
+                        "price" => 8.95,
+                        "available" => true,
+                    ),
+                    array(
+                        "category" => "fiction",
+                        "author" => "Evelyn Waugh",
+                        "title" => "Sword of Honour",
+                        "price" => 12.99,
+                        "available" => false
+                    ),
+                    array(
+                        "category" => "fiction",
+                        "author" => "Herman Melville",
+                        "title" => "Moby Dick",
+                        "isbn" => "0-553-21311-3",
+                        "price" => 8.99,
+                        "available" => true,
+                    ),
+                    array(
+                        "category" => "fiction",
+                        "author" => "J. R. R. Tolkien",
+                        "title" => "The Lord of the Rings",
+                        "isbn" => "0-395-19395-8",
+                        "price" => 22.99,
+                        "available" => false
+                    )
+                ),
+                "$..book[?(@.author in [$.authors])]"
             )
         );
     }


### PR DESCRIPTION
This is a quick POC related to:
* #68

Reason I'd like to see this addition is that some optimized json data schemas normalize the data in order to optimize transport size.
This means references are collected in a meta-data space while the original data structure only contains references to that meta-data space.

A good example is https://jsonapi.org/:
```json
{
  "links": {
    "self": "http://example.com/articles",
    "next": "http://example.com/articles?page[offset]=2",
    "last": "http://example.com/articles?page[offset]=10"
  },
  "data": [{
    "type": "articles",
    "id": "1",
    "attributes": {
      "title": "JSON:API paints my bikeshed!"
    },
    "relationships": {
      "author": {
        "links": {
          "self": "http://example.com/articles/1/relationships/author",
          "related": "http://example.com/articles/1/author"
        },
        "data": { "type": "people", "id": "9" }
      },
      "comments": {
        "links": {
          "self": "http://example.com/articles/1/relationships/comments",
          "related": "http://example.com/articles/1/comments"
        },
        "data": [
          { "type": "comments", "id": "5" },
          { "type": "comments", "id": "12" }
        ]
      }
    },
    "links": {
      "self": "http://example.com/articles/1"
    }
  }],
  "included": [{
    "type": "people",
    "id": "9",
    "attributes": {
      "firstName": "Dan",
      "lastName": "Gebhardt",
      "twitter": "dgeb"
    },
    "links": {
      "self": "http://example.com/people/9"
    }
  }, {
    "type": "comments",
    "id": "5",
    "attributes": {
      "body": "First!"
    },
    "relationships": {
      "author": {
        "data": { "type": "people", "id": "2" }
      }
    },
    "links": {
      "self": "http://example.com/comments/5"
    }
  }, {
    "type": "comments",
    "id": "12",
    "attributes": {
      "body": "I like XML better"
    },
    "relationships": {
      "author": {
        "data": { "type": "people", "id": "9" }
      }
    },
    "links": {
      "self": "http://example.com/comments/12"
    }
  }]
}
``` 

With the extension resolving the detail data of the comments of an entry becomes much easier:
`$.included[?(@.id in [$.data[0].relationships.comments.data[*].id])]`

------

There are still some open things in my mind:
* I had to use the `$hasDiverged` return value to decide if the result needs to be unwrapped in order to make the above outline scenario and the unit tests work. I'm currently not sure what this does and why I have to do this.
And I think the unit test lacks a test case because currently seems to hit only scenarios where `$hasDiverged` set to true.
* The spec adjustments seems wrong / incomplete: `in_array    = value 'in' '[' value (',' value)* | jsonpath ']'` Directly allowing `jsonpath` conflicts with the "known" limitations of value: "Jsonpaths in value return the first element of the set or false if no result."
So this conflicts and most likely also hints that this is a API-Break because the limitation essentially no longer exists for in_array - which can change the behavior of existing expressions - which is bad.
One Idea I could see is that in_array as a more poly-morph syntax - the spec could be: `in_array    = value 'in' ('[' value (',' value)* ']' | jsonpath)`
* Traditional: `$..book[?(@.author in [$.authors[0], $.authors[2]])]`
* Extended: `$..book[?(@.author in $.authors)]`


Anyhow, it's late here and I'm fighting with falling asleep :) 
Feedback would be great but I'll revisit later in any case.
