### PR TITLE
syntax cleanup, set minimum PHP version to 5.6

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup PHP with specific version
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '5.4'
+        php-version: '5.6'
 
     - name: Validate composer.json and composer.lock
       run: composer validate --strict

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4"
+        "php": ">=5.6"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/src/Galbar/JsonPath/Expression/Comparison.php
+++ b/src/Galbar/JsonPath/Expression/Comparison.php
@@ -30,15 +30,15 @@ class Comparison
         }
         if ($comparator === Language\Token::COMP_EQ) {
             return $left === $right;
-        } else if ($comparator === Language\Token::COMP_NEQ) {
+        } elseif ($comparator === Language\Token::COMP_NEQ) {
             return $left !== $right;
-        } else if ($comparator === Language\Token::COMP_LT) {
+        } elseif ($comparator === Language\Token::COMP_LT) {
             return $left < $right;
-        } else if ($comparator === Language\Token::COMP_GT) {
+        } elseif ($comparator === Language\Token::COMP_GT) {
             return $left > $right;
-        } else if ($comparator === Language\Token::COMP_LTE) {
+        } elseif ($comparator === Language\Token::COMP_LTE) {
             return $left <= $right;
-        } else if ($comparator === Language\Token::COMP_GTE) {
+        } elseif ($comparator === Language\Token::COMP_GTE) {
             return $left >= $right;
         } else { // $comparator === Language\Token::COMP_RE_MATCH
             if (is_string($right) && is_string($left)) {

--- a/src/Galbar/JsonPath/Expression/Value.php
+++ b/src/Galbar/JsonPath/Expression/Value.php
@@ -26,15 +26,15 @@ class Value
     {
         if ($expression === Language\Token::VAL_NULL) {
             return null;
-        } else if ($expression === Language\Token::VAL_TRUE) {
+        } elseif ($expression === Language\Token::VAL_TRUE) {
             return true;
-        } else if ($expression === Language\Token::VAL_FALSE) {
+        } elseif ($expression === Language\Token::VAL_FALSE) {
             return false;
-        } else if (is_numeric($expression)) {
+        } elseif (is_numeric($expression)) {
             return floatval($expression);
-        } else if (preg_match(Language\Regex::EXPR_STRING, $expression)) {
+        } elseif (preg_match(Language\Regex::EXPR_STRING, $expression)) {
             return substr($expression, 1, strlen($expression) - 2);
-        } else if (preg_match(Language\Regex::EXPR_REGEX, $expression)) {
+        } elseif (preg_match(Language\Regex::EXPR_REGEX, $expression)) {
             return $expression;
         } else {
             $match = array();
@@ -54,8 +54,7 @@ class Value
                 if ($length) {
                     if (is_array($result[0])) {
                         return (float) count($result[0]);
-                    }
-                    if (is_string($result[0])) {
+                    } elseif (is_string($result[0])) {
                         return (float) strlen($result[0]);
                     }
                     return false;

--- a/src/Galbar/JsonPath/InvalidJsonPathException.php
+++ b/src/Galbar/JsonPath/InvalidJsonPathException.php
@@ -35,6 +35,6 @@ class InvalidJsonPathException extends \Exception
      */
     public function __construct($token)
     {
-        parent::__construct("Error in JSONPath near '" . $token . "'", 0, null);
+        parent::__construct("Error in JSONPath near '{$token}'", 0, null);
     }
 }

--- a/src/Galbar/JsonPath/JsonObject.php
+++ b/src/Galbar/JsonPath/JsonObject.php
@@ -121,17 +121,17 @@ class JsonObject
     {
         if ($json === null) {
             $this->jsonObject = array();
-        } else if (is_string($json)) {
+        } elseif (is_string($json)) {
             $this->jsonObject = json_decode($json, true);
             if ($this->jsonObject === null) {
-                throw new InvalidJsonException("string does not contain a valid JSON object.");
+                throw new InvalidJsonException('String does not contain a valid JSON object.');
             }
-        } else if (is_array($json)) {
+        } elseif (is_array($json)) {
             $this->jsonObject = $json;
-        } else if (is_object($json)){
+        } elseif (is_object($json)){
             $this->jsonObject = json_decode(json_encode($json), true);
         } else {
-            throw new InvalidJsonException("value does not encode a JSON object.");
+            throw new InvalidJsonException('Value does not encode a JSON object.');
         }
         $this->smartGet = $smartGet;
     }
@@ -198,7 +198,7 @@ class JsonObject
      *
      * @return string
      */
-    public function getJson($options=0)
+    public function getJson($options = 0)
     {
         return json_encode($this->jsonObject, $options);
     }

--- a/src/Galbar/JsonPath/JsonPath.php
+++ b/src/Galbar/JsonPath/JsonPath.php
@@ -58,7 +58,7 @@ class JsonPath
                 } else {
                     $jsonPath = $match[2];
                 }
-            } else if (Language\ChildSelector::match($jsonPath, $match)) {
+            } elseif (Language\ChildSelector::match($jsonPath, $match)) {
                 $contents = $match[0];
                 foreach ($selection as &$partial) {
                     list($result, $newHasDiverged) = Operation\SelectChildren::apply($root, $partial, $contents, $createInexistent);
@@ -71,12 +71,12 @@ class JsonPath
                 } else {
                     $jsonPath = $match[1];
                 }
-            } else if (preg_match(Language\Regex::RECURSIVE_SELECTOR, $jsonPath, $match)) {
+            } elseif (preg_match(Language\Regex::RECURSIVE_SELECTOR, $jsonPath, $match)) {
                 $recursivePath = $match[1];
                 if ($recursivePath[0] === '[') {
-                    $recursivePath = "$$recursivePath";
+                    $recursivePath = "${$recursivePath}";
                 } else {
-                    $recursivePath = "$.$recursivePath";
+                    $recursivePath = "$.{$recursivePath}";
                 }
                 foreach ($selection as &$partial) {
                     list($result, $newHasDiverged) = Operation\GetRecursive::apply($root, $partial, $recursivePath);
@@ -87,7 +87,7 @@ class JsonPath
                     $hasDiverged = $hasDiverged || $newHasDiverged;
                     break;
                 } else {
-                    $jsonPath = "";
+                    $jsonPath = '';
                 }
             } else {
                 throw new \JsonPath\InvalidJsonPathException($jsonPath);

--- a/src/Galbar/JsonPath/Language/Token.php
+++ b/src/Galbar/JsonPath/Language/Token.php
@@ -28,6 +28,7 @@ class Token
     const EXPRESSION_END = ')';
     const ALL = '*';
     const COMA = ',';
+    const COMMA = ',';
     const COLON = ':';
     const COMP_EQ = '==';
     const COMP_NEQ = '!=';

--- a/src/Galbar/JsonPath/Operation/SelectChildren.php
+++ b/src/Galbar/JsonPath/Operation/SelectChildren.php
@@ -49,7 +49,7 @@ class SelectChildren
         } else if (preg_match(Language\Regex::CHILD_NAME_LIST, $contents, $match)) {
             $names = array_map(
                 function($x) { return trim($x, " \t\n\r\0\x0B'\""); },
-                explode(Language\Token::COMA, $contents)
+                explode(Language\Token::COMMA, $contents)
             );
             if (count($names) > 1) {
                 $hasDiverged = true;

--- a/src/Galbar/Utilities/ArraySlice.php
+++ b/src/Galbar/Utilities/ArraySlice.php
@@ -61,7 +61,7 @@ class ArraySlice
             if ($endpoint < 0) {
                 $endpoint = ($step < 0 ? -1 : 0);
             }
-        } else if ($endpoint >= $length) {
+        } elseif ($endpoint >= $length) {
             $endpoint = ($step < 0 ? $length - 1 : $length);
         }
         return $endpoint;
@@ -71,7 +71,7 @@ class ArraySlice
     {
         if ($step === null) {
             $step = 1;
-        } else if ($step === 0) {
+        } elseif ($step === 0) {
             throw new \Exception("Step cannot be 0");
         }
 


### PR DESCRIPTION
- No functional changes

Minor syntax cleanup
- changed `else if` to `elseif`
- added curly braces to parsed strings
- replaced double-quoted strings with single-quoted when parsing not needed

- Updated composer to require minimum PHP `5.6`, but should we bump this to at least `7.x`? It would be nice to remove the usage of the now-defunct `list()` construct, for example.

Overall, very handy little library. Let's keep it fresh.
